### PR TITLE
Truthhits and Momentum Range

### DIFF
--- a/sim/include/CaloTree.h
+++ b/sim/include/CaloTree.h
@@ -46,7 +46,7 @@ public:
   void accumulateHits(CaloHit aHit);
   void accumulateEnergy(double eleak, int type);
   void accumulateOPsCer(bool isCoreC = 0, int nOPs = 1);
-  void saveBeamXYZE(string, int, float, float, float, float, float, float, float);
+  void saveBeamXYZEPxPyPz(string, int, float, float, float, float, float, float, float);
 
   // for histogrming...
   std::string title;

--- a/sim/include/CaloTree.h
+++ b/sim/include/CaloTree.h
@@ -46,7 +46,7 @@ public:
   void accumulateHits(CaloHit aHit);
   void accumulateEnergy(double eleak, int type);
   void accumulateOPsCer(bool isCoreC = 0, int nOPs = 1);
-  void saveBeamXYZE(string, int, float, float, float, float);
+  void saveBeamXYZE(string, int, float, float, float, float, float, float, float);
 
   // for histogrming...
   std::string title;
@@ -141,6 +141,9 @@ private:
   float m_beamY;
   float m_beamZ;
   float m_beamE;
+  float m_beamPX; // GeV
+  float m_beamPY; // GeV
+  float m_beamPZ; // GeV
   string m_beamType;
 
   // truth hit variables (no sipm or time or position smearing applied)

--- a/sim/include/CaloTree.h
+++ b/sim/include/CaloTree.h
@@ -74,7 +74,7 @@ private:
 
   string beamType;
   int beamID;
-  float beamX, beamY, beamZ, beamE;
+  float beamX, beamY, beamZ, beamE, beamPX, beamPY, beamPZ;
   //
   string runConfig;
   int runNumber;
@@ -85,6 +85,7 @@ private:
   bool createNtuple;
 
   bool saveTruthHits;
+  bool isMuon;
 
   // hit data in csv file
   map<string, int> csvEvents; // number of events to be written to csv file.

--- a/sim/paramBatch03_single.mac
+++ b/sim/paramBatch03_single.mac
@@ -20,9 +20,12 @@
 #$$$ gun_y_max        -2.50     (cm)
 #$$$ gun_z_min        -105.0     (cm)
 #$$$ gun_z_max        -105.0     (cm)
-#$$$ pMomentum_x      0.0
-#$$$ pMomentum_y      0.0
-#$$$ pMomentum_z      1.0
+#$$$ pMomentum_x_min    0.0
+#$$$ pMomentum_x_max    0.0
+#$$$ pMomentum_y_min    0.0
+#$$$ pMomentum_y_max    0.0
+#$$$ pMomentum_z_min    1.0
+#$$$ pMomentum_z_max    1.0
 
 #$$$ csvHits2dSC       0  (number of events to save 2D hits in a csv file)
 #$$$ csvHits2dCH       0

--- a/sim/src/B4PrimaryGeneratorAction.cc
+++ b/sim/src/B4PrimaryGeneratorAction.cc
@@ -190,7 +190,7 @@ void B4PrimaryGeneratorAction::GeneratePrimaries(G4Event *anEvent)
     // cout<<"B4PrimaryGeneratorAction::GeneratePrimaries set a particle..."<<endl;
     // cout<<"   (x,y,z,en)="<<x<<",  "<<y<<",  "<<z<<",  "<<en<<",  "<<ptype<<endl;
     int pdgid = particleDefinition->GetPDGEncoding();
-    hh->saveBeamXYZE(ptype, pdgid, x, y, z, en, px, py, pz);
+    hh->saveBeamXYZEPxPyPz(ptype, pdgid, x, y, z, en, px, py, pz);
   }
 }
 

--- a/sim/src/B4PrimaryGeneratorAction.cc
+++ b/sim/src/B4PrimaryGeneratorAction.cc
@@ -174,9 +174,9 @@ void B4PrimaryGeneratorAction::GeneratePrimaries(G4Event *anEvent)
 
     float en = ((hh->getParamF("gun_energy_max") - hh->getParamF("gun_energy_min")) * G4UniformRand() + hh->getParamF("gun_energy_min")) * GeV;
     string ptype = hh->getParamS("gun_particle");
-    float px = (hh->getParamF("pMomentum_x"));
-    float py = (hh->getParamF("pMomentum_y"));
-    float pz = (hh->getParamF("pMomentum_z"));
+    float px = ((hh->getParamF("pMomentum_x_max") - hh->getParamF("pMomentum_x_min")) * G4UniformRand() + hh->getParamF("pMomentum_x_min"));
+    float py = ((hh->getParamF("pMomentum_y_max") - hh->getParamF("pMomentum_y_min")) * G4UniformRand() + hh->getParamF("pMomentum_y_min"));
+    float pz = ((hh->getParamF("pMomentum_z_max") - hh->getParamF("pMomentum_z_min")) * G4UniformRand() + hh->getParamF("pMomentum_z_min"));
 
     G4int nofParticles = 1;
     fParticleGun = new G4ParticleGun(nofParticles);
@@ -190,7 +190,7 @@ void B4PrimaryGeneratorAction::GeneratePrimaries(G4Event *anEvent)
     // cout<<"B4PrimaryGeneratorAction::GeneratePrimaries set a particle..."<<endl;
     // cout<<"   (x,y,z,en)="<<x<<",  "<<y<<",  "<<z<<",  "<<en<<",  "<<ptype<<endl;
     int pdgid = particleDefinition->GetPDGEncoding();
-    hh->saveBeamXYZE(ptype, pdgid, x, y, z, en);
+    hh->saveBeamXYZE(ptype, pdgid, x, y, z, en, px, py, pz);
   }
 }
 

--- a/sim/src/CaloTree.cc
+++ b/sim/src/CaloTree.cc
@@ -191,6 +191,9 @@ CaloTree::CaloTree(string macFileName, int argc, char **argv)
   tree->Branch("beamE", &m_beamE);
   tree->Branch("beamID", &m_beamID);
   tree->Branch("beamType", &m_beamType);
+  tree->Branch("beamPX", &m_beamPX);
+  tree->Branch("beamPY", &m_beamPY);
+  tree->Branch("beamPZ", &m_beamPZ);
 
   tree->Branch("ntruthhits", &m_nhitstruth);
   tree->Branch("truthhit_pid", &m_pidtruth);
@@ -325,6 +328,9 @@ void CaloTree::EndEvent()
     m_beamX = beamX;
     m_beamY = beamY;
     m_beamZ = beamZ;
+    m_beamPX = beamPX;
+    m_beamPY = beamPY;
+    m_beamPZ = beamPZ;
     m_beamE = beamE;
     m_beamID = beamID;
     m_beamType = beamType;
@@ -453,7 +459,10 @@ void CaloTree::saveBeamXYZE(string ptype, int pdgid, float x, float y, float z,
   beamX = x; // in mm
   beamY = y;
   beamZ = z;
-  beamE = en; // in MeV
+  beamE = en; in MeV
+  beamPX = px;
+  beamPY = py;
+  beamPZ = pz;
 }
 
 // ########################################################################
@@ -476,6 +485,9 @@ void CaloTree::clearCaloTree()
   m_beamX = 0.0;
   m_beamY = 0.0;
   m_beamZ = 0.0;
+  m_beamPX = 0.0;
+  m_beamPY = 0.0;
+  m_beamPZ = 0.0;
   m_beamE = 0.0;
   m_beamID = 0;
   m_beamType = " ";

--- a/sim/src/CaloTree.cc
+++ b/sim/src/CaloTree.cc
@@ -593,7 +593,7 @@ void CaloTree::clearCaloTree()
 // ########################################################################
 void CaloTree::accumulateHits(CaloHit ah)
 {
-  if (saveTruthHits && ah.edep >= 1.0e-6 && (ah.calotype > 1 || isMuon && ah.calotype == 1))
+  if (saveTruthHits && ah.edep >= 1.0e-6 && (ah.calotype > 1 || (isMuon && ah.calotype == 1)))
   {
     // save the truth hit in the scintillating and cherenkov fibers.
     // larger than 1 eV

--- a/sim/src/CaloTree.cc
+++ b/sim/src/CaloTree.cc
@@ -576,7 +576,7 @@ void CaloTree::clearCaloTree()
 // ########################################################################
 void CaloTree::accumulateHits(CaloHit ah)
 {
-  if (saveTruthHits && ah.calotype > 1 && ah.edep >= 1.0e-6)
+  if (saveTruthHits && ah.calotype >= 1 && ah.edep >= 1.0e-6)
   {
     // save the truth hit in the scintillating and cherenkov fibers.
     // larger than 1 eV

--- a/sim/src/CaloTree.cc
+++ b/sim/src/CaloTree.cc
@@ -74,6 +74,7 @@ CaloTree::CaloTree(string macFileName, int argc, char **argv)
   eventCountsALL = 0;
 
   saveTruthHits = false;
+  isMuon = false; // default is not muon
   if (getParamS("saveTruthHits").compare(0, 4, "true") == 0)
     saveTruthHits = true;
 
@@ -452,17 +453,19 @@ void CaloTree::EndJob()
 }
 // ########################################################################
 void CaloTree::saveBeamXYZE(string ptype, int pdgid, float x, float y, float z,
-                            float en)
+                            float en, float px, float py, float pz)
 {
   beamType = ptype; // sting pi+. e+ mu+ etc.
   beamID = pdgid;
   beamX = x; // in mm
   beamY = y;
   beamZ = z;
-  beamE = en; in MeV
+  beamE = en;
   beamPX = px;
   beamPY = py;
   beamPZ = pz;
+
+  isMuon = (abs(pdgid) == 13);
 }
 
 // ########################################################################
@@ -491,6 +494,7 @@ void CaloTree::clearCaloTree()
   m_beamE = 0.0;
   m_beamID = 0;
   m_beamType = " ";
+  isMuon = false;
 
   m_nhitstruth = 0;
   m_pidtruth.clear();
@@ -585,10 +589,11 @@ void CaloTree::clearCaloTree()
   mP_nOPsCer_Sci = 0;
 }
 
+
 // ########################################################################
 void CaloTree::accumulateHits(CaloHit ah)
 {
-  if (saveTruthHits && ah.calotype >= 1 && ah.edep >= 1.0e-6)
+  if (saveTruthHits && ah.edep >= 1.0e-6 && (ah.calotype > 1 || isMuon && ah.calotype == 1))
   {
     // save the truth hit in the scintillating and cherenkov fibers.
     // larger than 1 eV

--- a/sim/src/CaloTree.cc
+++ b/sim/src/CaloTree.cc
@@ -452,7 +452,7 @@ void CaloTree::EndJob()
   fout->Close();
 }
 // ########################################################################
-void CaloTree::saveBeamXYZE(string ptype, int pdgid, float x, float y, float z,
+void CaloTree::saveBeamXYZEPxPyPz(string ptype, int pdgid, float x, float y, float z,
                             float en, float px, float py, float pz)
 {
   beamType = ptype; // sting pi+. e+ mu+ etc.


### PR DESCRIPTION
the first commit contains a small change on the truth hits to include collecting truth hits for Rods (calotype=1) and the second contains implementation of momentum range control and access within TTree.